### PR TITLE
Add notebook for distance spotted season comparison

### DIFF
--- a/notebooks/06 Bones early vs 2024 distance spotted tests.ipynb
+++ b/notebooks/06 Bones early vs 2024 distance spotted tests.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "21f1daf6",
+   "metadata": {},
+   "source": [
+    "# Distance spotted: early vs latest seasons\n",
+    "\n",
+    "This notebook compares the mean `Pre: Distance spotted` between early seasons and the latest season (2024) for each habitat.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cff86df4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "from scipy.stats import ttest_ind, mannwhitneyu\n",
+    "\n",
+    "# Seasons to compare\n",
+    "early_years = [2003, 2007, 2008, 2011, 2018, 2019]\n",
+    "latest_year = 2024\n",
+    "\n",
+    "# Load data\n",
+    "df_transects = pd.read_pickle('../data/pkl/df_transects.pkl')\n",
+    "df_occurrences = pd.read_pickle('../data/pkl/df_occurrences.pkl')\n",
+    "\n",
+    "# Merge occurrences with transect info\n",
+    "df = df_occurrences.merge(\n",
+    "    df_transects[['UID', 'Pre: Transect physical habitat', 'Pre: On old reserve?', 'start_time']],\n",
+    "    how='left',\n",
+    "    left_on='TransectUID',\n",
+    "    right_on='UID'\n",
+    ")\n",
+    "\n",
+    "df['Pre: Distance spotted'] = pd.to_numeric(df['Pre: Distance spotted'], errors='coerce')\n",
+    "df['Year'] = pd.to_datetime(df['start_time']).dt.year\n",
+    "\n",
+    "df_cleaned = df\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dc515d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "results = []\n",
+    "\n",
+    "for habitat in df_cleaned['Pre: Transect physical habitat'].dropna().unique():\n",
+    "    df_habitat = df_cleaned[df_cleaned['Pre: Transect physical habitat'] == habitat]\n",
+    "\n",
+    "    group_early = df_habitat[df_habitat['Year'].isin(early_years)]['Pre: Distance spotted'].dropna()\n",
+    "    group_latest = df_habitat[df_habitat['Year'] == latest_year]['Pre: Distance spotted'].dropna()\n",
+    "\n",
+    "    if len(group_early) > 0 and len(group_latest) > 0:\n",
+    "        stat, p = ttest_ind(group_latest, group_early, equal_var=False)\n",
+    "\n",
+    "        results.append({\n",
+    "            \"Habitat\": habitat,\n",
+    "            \"Mean (early)\": group_early.mean(),\n",
+    "            \"Mean (2024)\": group_latest.mean(),\n",
+    "            \"T-stat\": stat,\n",
+    "            \"p-value\": p,\n",
+    "            \"Significant (p<0.05)\": p < 0.05\n",
+    "        })\n",
+    "    else:\n",
+    "        print(f\"⚠️ Skipping {habitat}: one of the groups has no data\")\n",
+    "\n",
+    "# Display results\n",
+    "comparison_by_habitat = pd.DataFrame(results).round(3)\n",
+    "comparison_by_habitat\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d59be9cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Optional: Mann–Whitney U test if assumptions for t-test are not met\n",
+    "# Replace the t-test in the loop above with the following line:\n",
+    "# stat, p = mannwhitneyu(group_latest, group_early, alternative='two-sided')\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ numpy
 pandas
 matplotlib
 scikit-learn
+scipy
 
 # DB connectors
 SQLAlchemy


### PR DESCRIPTION
## Summary
- add notebook comparing early seasons to 2024 for distance spotted by habitat
- include SciPy in requirements for statistical tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897a59789b48329879181a07777ad9f