### PR TITLE
Filter transects by year and habitat for summary table

### DIFF
--- a/notebooks/04 Bones create summary table-all.ipynb
+++ b/notebooks/04 Bones create summary table-all.ipynb
@@ -1161,48 +1161,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Filter transects to only those marked as \"on old reserve\"\n",
-    "df_old_reserve_transects = df_transects[df_transects[\"Pre: On old reserve?\"] == \"Yes\"].copy()\n",
-    "valid_transect_uids = df_old_reserve_transects['UID']\n",
+    "# Filter transects excluding year 2008 and most 2024 transects (keep 2024 'shrubs closed')\n",
+    "df_transects['Year'] = pd.to_datetime(df_transects['start_time']).dt.year\n",
+    "mask_not_2008 = df_transects['Year'] != 2008\n",
+    "mask_keep_2024 = ~((df_transects['Year'] == 2024) & (df_transects['Pre: Transect physical habitat'] != 'shrubs closed'))\n",
+    "df_filtered_transects = df_transects[mask_not_2008 & mask_keep_2024].copy()\n",
+    "valid_transect_uids = df_filtered_transects['UID']\n",
     "\n",
-    "# Count by 'Pre: Transect physical habitat'\n",
-    "counts = df_old_reserve_transects[\"Pre: Transect physical habitat\"].value_counts()\n",
-    "\n",
-    "# Convert to a single-row DataFrame with habitat types as columns\n",
-    "summary_table = pd.DataFrame([counts])\n",
-    "summary_table.index = ['# of transects']\n",
+    "# Initialize summary table with a single 'All' column\n",
+    "summary_table = pd.DataFrame({'All': [len(df_filtered_transects)]}, index=['# of transects'])\n",
     "\n",
     "# Step 2: Join df_occurrences to get the habitat info\n",
     "df_occ_with_habitat = df_occurrences.merge(\n",
-    "    df_old_reserve_transects[['UID', 'Pre: Transect physical habitat']],\n",
+    "    df_filtered_transects[['UID', 'Pre: Transect physical habitat']],\n",
     "    how='inner',\n",
     "    left_on='TransectUID',\n",
     "    right_on='UID'\n",
     ")\n",
     "\n",
-    "# Step 3: Group and count occurrences (MNI)\n",
-    "mni_counts = df_occ_with_habitat['Pre: Transect physical habitat'].value_counts()\n",
-    "\n",
-    "# Step 4: Add MNI row to the summary table\n",
-    "summary_table.loc['MNI (n)'] = summary_table.columns.map(mni_counts).fillna(0).astype(int)\n",
+    "# Step 3: Count occurrences (MNI) across all habitats\n",
+    "summary_table.loc['MNI (n)'] = len(df_occ_with_habitat)\n",
     "\n",
     "# By Taxa\n",
-    "# Filter transects to 'old reserve' only\n",
     "df_occ_with_habitat['Taxon Label'] = df_occ_with_habitat['Post: Taxon guess?'].fillna(\n",
     "    df_occ_with_habitat['Pre: Taxon']\n",
     ")\n",
     "\n",
-    "taxon_summary = df_occ_with_habitat.pivot_table(\n",
-    "    index='Taxon Label',\n",
-    "    columns='Pre: Transect physical habitat',\n",
-    "    values='ID',\n",
-    "    aggfunc='count',\n",
-    "    fill_value=0\n",
-    ")\n",
-    "\n",
-    "# Align and append to summary_table\n",
-    "taxon_summary = taxon_summary.reindex(columns=summary_table.columns, fill_value=0)\n",
-    "summary_table = pd.concat([summary_table, taxon_summary])"
+    "taxon_summary = df_occ_with_habitat['Taxon Label'].value_counts().to_frame(name='All')\n",
+    "summary_table = pd.concat([summary_table, taxon_summary])\n"
    ]
   },
   {
@@ -1302,20 +1288,11 @@
    "source": [
     "# km2 covered\n",
     "# Multiply each transect's distance by 0.05 to estimate area\n",
-    "df_old_reserve_transects['area_km2'] = df_old_reserve_transects['distance_km'] * 0.05\n",
+    "df_filtered_transects['area_km2'] = df_filtered_transects['distance_km'] * 0.05\n",
     "\n",
-    "# Sum area per habitat type\n",
-    "area_by_habitat = df_old_reserve_transects.groupby(\"Pre: Transect physical habitat\")[\"area_km2\"].sum()\n",
-    "\n",
-    "# Align with column order of summary_table\n",
-    "#area_row = summary_table.columns.map(area_by_habitat).fillna(0).round(2)\n",
-    "area_row = pd.Series(summary_table.columns.map(area_by_habitat)).fillna(0).astype(float).round(2)\n",
-    "# Now assign the row (note: index should match summary_table.columns)\n",
-    "area_row.index = summary_table.columns\n",
-    "\n",
-    "# Add to summary_table\n",
-    "summary_table.loc['km2 covered'] = area_row\n",
-    "# summary_table.head()"
+    "# Sum total area\n",
+    "total_area = round(df_filtered_transects['area_km2'].sum(), 2)\n",
+    "summary_table.loc['km2 covered'] = total_area\n"
    ]
   },
   {
@@ -1347,7 +1324,7 @@
     "\n",
     "mni_per_km2 = (mni_row / area_row.replace(0, pd.NA)).round().fillna(0)\n",
     "summary_table.loc['MNI/km2'] = pd.Series(mni_per_km2, index=summary_table.columns)\n",
-    "summary_table.loc['MNI/km2'].apply(type)"
+    "summary_table.loc['MNI/km2'].apply(type)\n"
    ]
   },
   {
@@ -1369,21 +1346,19 @@
     "\n",
     "# Merge with df_transects to get the habitat\n",
     "df_instances_full = df_instances_with_occ.merge(\n",
-    "    df_transects[['UID', 'Pre: Transect physical habitat', 'Pre: On old reserve?']],\n",
+    "    df_transects[['UID', 'Pre: Transect physical habitat', 'start_time']],\n",
     "    how='left',\n",
     "    left_on='TransectUID',\n",
     "    right_on='UID',\n",
     "    suffixes=('', '_transect')\n",
     ")\n",
     "\n",
-    "# Filter to \"old reserve\" transects (if needed)\n",
+    "# Filter to selected transects\n",
+    "df_instances_filtered = df_instances_full[df_instances_full['TransectUID'].isin(valid_transect_uids)].copy()\n",
     "\n",
-    "df_instances_old_reserve = df_instances_full[df_instances_full[\"Pre: On old reserve?\"] == \"Yes\"].copy()\n",
-    "\n",
-    "# Count instances per habitat (aka NISP)\n",
-    "nisp_counts = df_instances_old_reserve['Pre: Transect physical habitat'].value_counts()\n",
-    "nisp_row = summary_table.columns.map(nisp_counts).fillna(0).astype(int)\n",
-    "summary_table.loc['NISP (# of bones)'] = nisp_row"
+    "# Total instances across all habitats (NISP)\n",
+    "nisp_total = len(df_instances_filtered)\n",
+    "summary_table.loc['NISP (# of bones)'] = nisp_total\n"
    ]
   },
   {
@@ -1402,7 +1377,7 @@
     "nisp_per_km2 = (nisp_row / area_row.replace(0, pd.NA)).round().fillna(0).astype(int)\n",
     "\n",
     "# Add to the summary table\n",
-    "summary_table.loc['NISP/km2'] = pd.Series(nisp_per_km2, index=summary_table.columns)"
+    "summary_table.loc['NISP/km2'] = pd.Series(nisp_per_km2, index=summary_table.columns)\n"
    ]
   },
   {
@@ -1422,35 +1397,22 @@
     ")\n",
     "\n",
     "df_briana_with_occ_transect = df_briana_with_occ.merge(\n",
-    "    df_transects[['UID', 'Pre: Transect physical habitat', 'Pre: On old reserve?']],\n",
+    "    df_transects[['UID', 'Pre: Transect physical habitat', 'start_time']],\n",
     "    how='left',\n",
     "    left_on='TransectUID',\n",
     "    right_on='UID',\n",
     "    suffixes=('', '_transect')\n",
     ")\n",
     "\n",
-    "# Only old reserve\n",
-    "df_briana_old_reserve = df_briana_with_occ_transect[\n",
-    "    df_briana_with_occ_transect['Pre: On old reserve?'] == 'Yes'\n",
-    "].copy()\n",
+    "# Only selected transects\n",
+    "df_briana_filtered = df_briana_with_occ_transect[df_briana_with_occ_transect['TransectUID'].isin(valid_transect_uids)].copy()\n",
     "\n",
-    "weathering_counts = df_briana_old_reserve.pivot_table(\n",
-    "    index='Weathering class',\n",
-    "    columns='Pre: Transect physical habitat',\n",
-    "    values='UID',\n",
-    "    aggfunc='count',\n",
-    "    fill_value=0\n",
-    ")\n",
-    "\n",
-    "weathering_percent = weathering_counts.div(weathering_counts.sum(axis=0), axis=1) * 100\n",
-    "weathering_percent = weathering_percent.round(1)\n",
-    "\n",
-    "# Reindex to match summary table column order\n",
-    "weathering_percent = weathering_percent.reindex(columns=summary_table.columns, fill_value=0)\n",
+    "weathering_counts = df_briana_filtered['Weathering class'].value_counts()\n",
+    "weathering_percent = (weathering_counts / weathering_counts.sum() * 100).round(1)\n",
     "\n",
     "# Add rows to summary table\n",
-    "for label, row in weathering_percent.iterrows():\n",
-    "    summary_table.loc[f'Weathering class {label} (%)'] = row"
+    "for label, value in weathering_percent.items():\n",
+    "    summary_table.loc[f'Weathering class {label} (%)'] = value\n"
    ]
   },
   {
@@ -1460,21 +1422,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Count total instances per habitat (denominator)\n",
-    "nisp_total = df_briana_old_reserve['Pre: Transect physical habitat'].value_counts()\n",
+    "# % buried bones\n",
+    "# Total instances across all habitats (denominator)\n",
+    "nisp_total = len(df_briana_filtered)\n",
     "\n",
-    "# Count buried instances per habitat (numerator)\n",
-    "buried = df_briana_old_reserve[df_briana_old_reserve['Buried?'] == 'Yes']\n",
-    "buried_counts = buried['Pre: Transect physical habitat'].value_counts()\n",
+    "# Buried instances (numerator)\n",
+    "buried = df_briana_filtered[df_briana_filtered['Buried?'] == 'Yes']\n",
     "\n",
     "# Calculate percentage\n",
-    "buried_percent = (buried_counts / nisp_total * 100).round(1)\n",
-    "\n",
-    "# Align with summary table columns\n",
-    "buried_row = summary_table.columns.map(buried_percent).fillna(0)\n",
-    "\n",
-    "# Add row to summary table\n",
-    "summary_table.loc['% buried bones'] = buried_row"
+    "buried_percent = round(len(buried) / nisp_total * 100, 1) if nisp_total else 0\n",
+    "summary_table.loc['% buried bones'] = buried_percent\n"
    ]
   },
   {
@@ -1491,19 +1448,13 @@
     "# Count only valid carnivore damage levels (as strings just in case)\n",
     "valid_damage_levels = {'1', '2', '3', '4'}\n",
     "\n",
-    "has_valid_carn_damage = df_briana_old_reserve[\n",
-    "    df_briana_old_reserve['Carn Damage 1 Level'].astype(str).isin(valid_damage_levels)\n",
+    "has_valid_carn_damage = df_briana_filtered[\n",
+    "    df_briana_filtered['Carn Damage 1 Level'].astype(str).isin(valid_damage_levels)\n",
     "]\n",
     "\n",
-    "carn_counts = has_valid_carn_damage['Pre: Transect physical habitat'].value_counts()\n",
-    "\n",
-    "# Calculate % per habitat\n",
-    "carn_percent = (carn_counts / nisp_total * 100).round(1)\n",
-    "\n",
-    "# Align with summary_table columns\n",
-    "carn_row = summary_table.columns.map(carn_percent).fillna(0)\n",
-    "\n",
-    "summary_table.loc['% bones with any carnivore damage'] = carn_row"
+    "# Calculate % across all habitats\n",
+    "carn_percent = round(len(has_valid_carn_damage) / nisp_total * 100, 1) if nisp_total else 0\n",
+    "summary_table.loc['% bones with any carnivore damage'] = carn_percent\n"
    ]
   },
   {
@@ -2041,10 +1992,10 @@
     "    df_instances.to_excel(writer, sheet_name='Instances', index=False)\n",
     "    df_briana_with_responses.to_excel(writer, sheet_name='Briana', index=False)\n",
     "    df_fire_with_responses.to_excel(writer, sheet_name='Fire', index=False)\n",
-    "    summary_table.to_excel(writer, sheet_name='TableData', index=False)\n",
+    "    summary_table.to_excel(writer, sheet_name='TableData')\n",
     "    df_transect_metadata.to_excel(writer, sheet_name='TransectData', index=False)\n",
-    "    \n",
-    "print(f\"✅ Excel saved to: {output_path}\")"
+    "\n",
+    "print(f\"✅ Excel saved to: {output_path}\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Collapse per-habitat grouping into a single `All` column when building the summary table
- Compute area, NISP, MNI, and weathering metrics across all filtered transects
- Export summary table to Excel with row headings preserved on the left

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c87f267808329b34d1aa15e8288d8