### PR TITLE
Add pairwise PERMANOVA with Bonferroni correction

### DIFF
--- a/notebooks/11 Bones PERMANOVA Analysis.ipynb
+++ b/notebooks/11 Bones PERMANOVA Analysis.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "9dcad510",
    "metadata": {},
    "outputs": [],
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "420a230c",
    "metadata": {},
    "outputs": [],
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "86d64d73",
    "metadata": {},
    "outputs": [],
@@ -130,18 +130,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "70296a0d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_98/3262861946.py:6: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.\n",
+      "  return df.applymap(lambda x: np.log2(x) + 1 if x > 0 else 0)\n"
+     ]
+    }
+   ],
    "source": [
-    "# Transform abundances: log2(x + 1) + 1\n",
-    "df_log = np.log2(df_matrix + 1) + 1\n"
+    "# Apply Anderson-style Log₂(x) + 1 Transformation\n",
+    "def log2_plus1_anderson(df):\n",
+    "    return df.applymap(lambda x: np.log2(x) + 1 if x > 0 else 0)\n",
+    "\n",
+    "# Apply transformation\n",
+    "df_log = log2_plus1_anderson(df_matrix)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "4817303d",
    "metadata": {},
    "outputs": [
@@ -176,7 +189,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>5.321</td>\n",
+       "      <td>3.086</td>\n",
        "      <td>0.001</td>\n",
        "      <td>3</td>\n",
        "      <td>60</td>\n",
@@ -188,10 +201,10 @@
       ],
       "text/plain": [
        "   test_statistic  p_value  df_between  df_within  permutations\n",
-       "0           5.321    0.001           3         60           999"
+       "0           3.086    0.001           3         60           999"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -220,10 +233,106 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "6e74457a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>group_1</th>\n",
+       "      <th>group_2</th>\n",
+       "      <th>test_statistic</th>\n",
+       "      <th>p_value</th>\n",
+       "      <th>p_value_corrected</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>grass closed</td>\n",
+       "      <td>shrubs closed</td>\n",
+       "      <td>3.526</td>\n",
+       "      <td>0.002</td>\n",
+       "      <td>0.012</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>grass closed</td>\n",
+       "      <td>shrubs open</td>\n",
+       "      <td>1.935</td>\n",
+       "      <td>0.062</td>\n",
+       "      <td>0.372</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>grass closed</td>\n",
+       "      <td>trees closed</td>\n",
+       "      <td>4.426</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.006</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>shrubs closed</td>\n",
+       "      <td>shrubs open</td>\n",
+       "      <td>2.556</td>\n",
+       "      <td>0.022</td>\n",
+       "      <td>0.132</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>shrubs closed</td>\n",
+       "      <td>trees closed</td>\n",
+       "      <td>1.906</td>\n",
+       "      <td>0.077</td>\n",
+       "      <td>0.462</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>shrubs open</td>\n",
+       "      <td>trees closed</td>\n",
+       "      <td>4.355</td>\n",
+       "      <td>0.001</td>\n",
+       "      <td>0.006</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         group_1        group_2  test_statistic  p_value  p_value_corrected\n",
+       "0   grass closed  shrubs closed           3.526    0.002              0.012\n",
+       "1   grass closed    shrubs open           1.935    0.062              0.372\n",
+       "2   grass closed   trees closed           4.426    0.001              0.006\n",
+       "3  shrubs closed    shrubs open           2.556    0.022              0.132\n",
+       "4  shrubs closed   trees closed           1.906    0.077              0.462\n",
+       "5    shrubs open   trees closed           4.355    0.001              0.006"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import itertools\n",
     "\n",

--- a/notebooks/11 Bones PERMANOVA Analysis.ipynb
+++ b/notebooks/11 Bones PERMANOVA Analysis.ipynb
@@ -1,32 +1,26 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "7fb2e33e-5c27-4d4e-9607-a318b1c215e4",
+   "cell_type": "markdown",
+   "id": "8b495a6e-8e64-4562-bbbf-9fcca1c6c54c",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid character '•' (U+2022) (3883255795.py, line 2)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;36m  Cell \u001b[0;32mIn[1], line 2\u001b[0;36m\u001b[0m\n\u001b[0;31m    •\tPERMANOVA analysis notebook that filters transects to the old reserve, excludes designated taxa, and builds a species-by-transect matrix for habitat comparisons\u001b[0m\n\u001b[0m    ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid character '•' (U+2022)\n"
-     ]
-    }
-   ],
    "source": [
-    "Summary\n",
+    "### PERMANOVA\n",
+    "\n",
     "•\tPERMANOVA analysis notebook that filters transects to the old reserve, excludes designated taxa, and builds a species-by-transect matrix for habitat comparisons\n",
+    "\n",
     "•\tImplemented a log₂(x + 1) + 1 abundance transformation to retain zeros and stabilise variance before analysis\n",
+    "\n",
     "•\tIntroduced PERMANOVA using Bray–Curtis distances with 999 permutations to test species composition differences across habitats\n",
+    "\n",
     "•\timplement a pure-Python PERMANOVA to avoid scikit-bio dependency\n",
+    "\n",
     "•\tAdded pairwise PERMANOVA with Bonferroni correction to identify significant differences between specific habitat pairs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "id": "9dcad510",
    "metadata": {},
    "outputs": [],
@@ -82,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "id": "420a230c",
    "metadata": {},
    "outputs": [],
@@ -109,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "id": "86d64d73",
    "metadata": {},
    "outputs": [],
@@ -130,23 +124,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "id": "70296a0d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_98/3262861946.py:6: FutureWarning: DataFrame.applymap has been deprecated. Use DataFrame.map instead.\n",
-      "  return df.applymap(lambda x: np.log2(x) + 1 if x > 0 else 0)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Apply Anderson-style Log₂(x) + 1 Transformation\n",
     "def log2_plus1_anderson(df):\n",
-    "    return df.applymap(lambda x: np.log2(x) + 1 if x > 0 else 0)\n",
+    "    return df.map(lambda x: np.log2(x) + 1 if x > 0 else 0)\n",
     "\n",
     "# Apply transformation\n",
     "df_log = log2_plus1_anderson(df_matrix)\n"
@@ -154,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "id": "4817303d",
    "metadata": {},
    "outputs": [
@@ -204,7 +189,7 @@
        "0           3.086    0.001           3         60           999"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -233,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "id": "6e74457a",
    "metadata": {},
    "outputs": [
@@ -271,16 +256,16 @@
        "      <td>grass closed</td>\n",
        "      <td>shrubs closed</td>\n",
        "      <td>3.526</td>\n",
-       "      <td>0.002</td>\n",
-       "      <td>0.012</td>\n",
+       "      <td>0.008</td>\n",
+       "      <td>0.048</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>grass closed</td>\n",
        "      <td>shrubs open</td>\n",
        "      <td>1.935</td>\n",
-       "      <td>0.062</td>\n",
-       "      <td>0.372</td>\n",
+       "      <td>0.068</td>\n",
+       "      <td>0.408</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -295,16 +280,16 @@
        "      <td>shrubs closed</td>\n",
        "      <td>shrubs open</td>\n",
        "      <td>2.556</td>\n",
-       "      <td>0.022</td>\n",
-       "      <td>0.132</td>\n",
+       "      <td>0.023</td>\n",
+       "      <td>0.138</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>shrubs closed</td>\n",
        "      <td>trees closed</td>\n",
        "      <td>1.906</td>\n",
-       "      <td>0.077</td>\n",
-       "      <td>0.462</td>\n",
+       "      <td>0.098</td>\n",
+       "      <td>0.588</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
@@ -320,15 +305,15 @@
       ],
       "text/plain": [
        "         group_1        group_2  test_statistic  p_value  p_value_corrected\n",
-       "0   grass closed  shrubs closed           3.526    0.002              0.012\n",
-       "1   grass closed    shrubs open           1.935    0.062              0.372\n",
+       "0   grass closed  shrubs closed           3.526    0.008              0.048\n",
+       "1   grass closed    shrubs open           1.935    0.068              0.408\n",
        "2   grass closed   trees closed           4.426    0.001              0.006\n",
-       "3  shrubs closed    shrubs open           2.556    0.022              0.132\n",
-       "4  shrubs closed   trees closed           1.906    0.077              0.462\n",
+       "3  shrubs closed    shrubs open           2.556    0.023              0.138\n",
+       "4  shrubs closed   trees closed           1.906    0.098              0.588\n",
        "5    shrubs open   trees closed           4.355    0.001              0.006"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/11 Bones PERMANOVA Analysis.ipynb
+++ b/notebooks/11 Bones PERMANOVA Analysis.ipynb
@@ -20,7 +20,8 @@
     "•\tPERMANOVA analysis notebook that filters transects to the old reserve, excludes designated taxa, and builds a species-by-transect matrix for habitat comparisons\n",
     "•\tImplemented a log₂(x + 1) + 1 abundance transformation to retain zeros and stabilise variance before analysis\n",
     "•\tIntroduced PERMANOVA using Bray–Curtis distances with 999 permutations to test species composition differences across habitats\n",
-    "•\timplement a pure-Python PERMANOVA to avoid scikit-bio dependency"
+    "•\timplement a pure-Python PERMANOVA to avoid scikit-bio dependency\n",
+    "•\tAdded pairwise PERMANOVA with Bonferroni correction to identify significant differences between specific habitat pairs"
    ]
   },
   {
@@ -209,6 +210,47 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8c4fe823",
+   "metadata": {},
+   "source": [
+    "### Pairwise PERMANOVA\n",
+    "\n",
+    "Pairwise PERMANOVA tests with Bonferroni correction to identify which habitat pairs differ significantly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e74457a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itertools\n",
+    "\n",
+    "unique_groups = np.unique(habitats.values)\n",
+    "pairs = list(itertools.combinations(unique_groups, 2))\n",
+    "pairwise_results = []\n",
+    "for g1, g2 in pairs:\n",
+    "    mask = habitats.isin([g1, g2]).values\n",
+    "    idx = np.where(mask)[0]\n",
+    "    sub_dm = dm[np.ix_(idx, idx)]\n",
+    "    sub_groups = habitats.iloc[idx].values\n",
+    "    res = permanova(sub_dm, grouping=sub_groups, permutations=999)\n",
+    "    pairwise_results.append({\n",
+    "        'group_1': g1,\n",
+    "        'group_2': g2,\n",
+    "        'test_statistic': res['test_statistic'],\n",
+    "        'p_value': res['p_value']\n",
+    "    })\n",
+    "pairwise_df = pd.DataFrame(pairwise_results)\n",
+    "pairwise_df['p_value_corrected'] = np.minimum(pairwise_df['p_value'] * len(pairs), 1.0)\n",
+    "pairwise_df = pairwise_df[['group_1','group_2','test_statistic','p_value','p_value_corrected']]\n",
+    "pairwise_df = pairwise_df.round(3)\n",
+    "pairwise_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7701c5f0-7312-413a-9e17-2ef13d298bac",
    "metadata": {},
    "source": [
@@ -223,14 +265,6 @@
     "| The pseudo-F = 5.32 suggests meaningful group separation in community composition.\n",
     "| Group structure (habitats) explains a significant portion of the dissimilarity in your Bray-Curtis distance matrix."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "609205b0-5a09-46fb-8853-e1803dcaad56",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- extend PERMANOVA notebook summary to mention pairwise analysis
- add pairwise PERMANOVA tests with Bonferroni-corrected p-values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a06d058ac08329abfe660d45da2812